### PR TITLE
Fix failing frontend test by removing testing-library dependency

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+// Ensure the main header renders
+test('renders the app header', () => {
+  const html = ReactDOMServer.renderToString(<App />);
+  expect(html).toMatch(/choose a show/i);
 });

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,5 +1,5 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+// jest-dom would normally add custom matchers such as
+// `toBeInTheDocument`, but the project does not rely on
+// those matchers.  Keeping this file ensures the test
+// environment is configured consistently without pulling
+// in an extra dependency.


### PR DESCRIPTION
## Summary
- simplify App.test.js to render with ReactDOMServer
- drop unused jest-dom import to avoid missing dependency errors

## Testing
- `CI=true npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_688ee730a4308329aade555773544fcc