### PR TITLE
Reset cached FlipRoller state on first load after update

### DIFF
--- a/frontend/src/components/FlipRoller.jsx
+++ b/frontend/src/components/FlipRoller.jsx
@@ -27,10 +27,19 @@ export default function FlipRoller() {
   const [target,        setTarget]       = useState(3);
 
   // ————— Persist state in localStorage —————
+  const CACHE_VERSION = '2';
+  const CACHE_VERSION_KEY = 'flipRollerCacheVersion';
+  const CACHE_STATE_KEY = 'flipRollerState';
 
   // On mount, try to hydrate from localStorage
   useEffect(() => {
-    const stored = localStorage.getItem('flipRollerState');
+    const cachedVersion = localStorage.getItem(CACHE_VERSION_KEY);
+    if (cachedVersion !== CACHE_VERSION) {
+      localStorage.removeItem(CACHE_STATE_KEY);
+      localStorage.setItem(CACHE_VERSION_KEY, CACHE_VERSION);
+      return;
+    }
+    const stored = localStorage.getItem(CACHE_STATE_KEY);
     if (stored) {
       try {
         const { history, allowance, target, ready, finished, selected } = JSON.parse(stored);
@@ -49,7 +58,7 @@ export default function FlipRoller() {
   // Whenever key pieces of state change, persist them
   useEffect(() => {
     const state = { history, allowance, target, ready, finished, selected };
-    localStorage.setItem('flipRollerState', JSON.stringify(state));
+    localStorage.setItem(CACHE_STATE_KEY, JSON.stringify(state));
   }, [history, allowance, target, ready, finished, selected]);
 
   /* ————————— existing logic unchanged ————————— */


### PR DESCRIPTION
### Motivation
- Prevent users upgrading to the repurposed app from seeing previously persisted choices while keeping the caching behavior for refresh protection.

### Description
- Add `CACHE_VERSION`, `CACHE_VERSION_KEY`, and `CACHE_STATE_KEY` constants and gate localStorage hydration on the stored cache version.
- On first load with a mismatched version the previous `flipRollerState` is removed and the new version is written, otherwise the cached state is hydrated as before.
- Switch all reads/writes to use `CACHE_STATE_KEY` so the version gating and state key are consistent and no other app logic was changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ddc094548329855dbf9b7f678fd1)